### PR TITLE
Add mapping.Dup() to create a dereferenced clone

### DIFF
--- a/mapping.go
+++ b/mapping.go
@@ -93,21 +93,15 @@ func (m *Mapping) Dup() Mapping {
 			new[k] = ns
 		case []string:
 			var ns []string
-			for _, sv := range vt {
-				ns = append(ns, sv)
-			}
+			ns = append(ns, vt...)
 			new[k] = ns
 		case []int:
 			var ns []int
-			for _, sv := range vt {
-				ns = append(ns, sv)
-			}
+			ns = append(ns, vt...)
 			new[k] = ns
 		case []bool:
 			var ns []bool
-			for _, sv := range vt {
-				ns = append(ns, sv)
-			}
+			ns = append(ns, vt...)
 			new[k] = ns
 		default:
 			new[k] = vt

--- a/mapping.go
+++ b/mapping.go
@@ -70,6 +70,52 @@ func (m *Mapping) DigMapping(keys ...string) Mapping {
 	}
 }
 
+// Dup creates a dereferenced copy of the Mapping
+func (m *Mapping) Dup() Mapping {
+	new := make(Mapping, len(*m))
+	for k, v := range *m {
+		switch vt := v.(type) {
+		case Mapping:
+			new[k] = vt.Dup()
+		case *Mapping:
+			new[k] = vt.Dup()
+		case []Mapping:
+			var ns []Mapping
+			for _, sv := range vt {
+				ns = append(ns, sv.Dup())
+			}
+			new[k] = ns
+		case []*Mapping:
+			var ns []Mapping
+			for _, sv := range vt {
+				ns = append(ns, sv.Dup())
+			}
+			new[k] = ns
+		case []string:
+			var ns []string
+			for _, sv := range vt {
+				ns = append(ns, sv)
+			}
+			new[k] = ns
+		case []int:
+			var ns []int
+			for _, sv := range vt {
+				ns = append(ns, sv)
+			}
+			new[k] = ns
+		case []bool:
+			var ns []bool
+			for _, sv := range vt {
+				ns = append(ns, sv)
+			}
+			new[k] = ns
+		default:
+			new[k] = vt
+		}
+	}
+	return new
+}
+
 // Cleans up a slice of interfaces into slice of actual values
 func cleanUpInterfaceArray(in []interface{}) []interface{} {
 	result := make([]interface{}, len(in))

--- a/mapping_test.go
+++ b/mapping_test.go
@@ -51,6 +51,47 @@ func TestDigMapping(t *testing.T) {
 	assert.Equal(t, "hello", m.Dig("foo", "bar", "baz"))
 }
 
+func TestDup(t *testing.T) {
+	m := Mapping{
+		"foo": Mapping{
+			"bar": "foobar",
+		},
+		"array": []string{
+			"hello",
+		},
+		"mappingarray": []Mapping{
+			{"bar": "foobar"},
+			{"foo": "barfoo"},
+		},
+	}
+
+	dup := m.Dup()
+
+	m.DigMapping("foo")["bar"] = "barbar"
+	arr := m.Dig("array").([]string)
+	arr = append(arr, "world")
+	m["array"] = arr
+
+	ma := m["mappingarray"].([]Mapping)
+	maa := ma[0]
+	maa["bar"] = "barbar"
+
+	assert.Equal(t, "barbar", m.Dig("foo", "bar"))
+	assert.Equal(t, "foobar", dup.Dig("foo", "bar"))
+
+	a := m.Dig("array").([]string)
+	b := dup.Dig("array").([]string)
+
+	assert.Len(t, a, 2)
+	assert.Len(t, b, 1)
+
+	am := m.Dig("mappingarray").([]Mapping)
+	bm := dup.Dig("mappingarray").([]Mapping)
+
+	assert.Equal(t, "barbar", am[0]["bar"])
+	assert.Equal(t, "foobar", bm[0]["bar"])
+}
+
 func TestUnmarshalYamlWithNil(t *testing.T) {
 	data := `foo: null`
 	var m Mapping


### PR DESCRIPTION
Needed to fix https://github.com/k0sproject/k0sctl/issues/188

Adds a `mapping.Dup()` function which returns a deep-copy that does not hold references to the existing items in the Mapping.
